### PR TITLE
Make fb email as username if possible

### DIFF
--- a/src/FacebookLoginBundle/Controller/CallbackController.php
+++ b/src/FacebookLoginBundle/Controller/CallbackController.php
@@ -201,7 +201,7 @@ class CallbackController implements FrameworkAwareInterface
             $member->gender = \in_array('gender', $saveData, true) ? $graphUser['gender'] : '';
             $member->email = ($graphUser['email'] && \in_array('email', $saveData, true)) ? $graphUser['email'] : '';
             $member->login = 1;
-            $member->username = $username;
+            $member->username = ($graphUser['email'] && \in_array('email', $saveData, true)) ? $graphUser['email'] : $username;
             $member->facebookId = $graphUser['id'];
             $member->language = \in_array('locale', $saveData, true) ? $graphUser['locale'] : '';
             $member->groups = $module->reg_groups;


### PR DESCRIPTION
In most cases, we use email as username. There are also few extensions which are in support of email as username. So it is helpful if you also make email as username when possible.

`terminal42/contao-mailusername`
`heimrichhannot/contao-email2username`
`asconsulting/member_email_username`


